### PR TITLE
BinaryFormatter obsolete as error in net7

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.targets
@@ -38,4 +38,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup Condition="'$(SupportsHotReload)' != 'false' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">
     <ProjectCapability Include="SupportsHotReload" />
   </ItemGroup>
+
+  <!--
+    BinaryFormatter infrastructure is obsolete as error in 7.0+.
+    When https://github.com/Microsoft/visualfsharp/issues/3207 is fixed,
+    remove the block below and move it into the shared .targets file.
+  -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0'))">
+    <WarningsAsErrors Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != 'true'">$(WarningsAsErrors);SYSLIB0011</WarningsAsErrors>
+  </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.VisualBasic.targets
@@ -126,6 +126,15 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <!--
+    BinaryFormatter infrastructure is obsolete as error in 7.0+.
+    When https://github.com/Microsoft/visualfsharp/issues/3207 is fixed,
+    remove the block below and move it into the shared .targets file.
+  -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0'))">
+    <WarningsAsErrors Condition="'$(EnableUnsafeBinaryFormatterSerialization)' != 'true'">$(WarningsAsErrors);SYSLIB0011</WarningsAsErrors>
+  </PropertyGroup>
+
+  <!--
     NOTE: We must hook directly to CoreCompile for compatibility with two phase XAML
           build. We also must not pull in a dependency on ResolveAssemblyReferences
           as the generated temporary project for xaml compilation has a hard-coded list


### PR DESCRIPTION
## Source breaking change notification - BinaryFormatter APIs obsolete as error

As part of [the BinaryFormatter long-term deprecation plan](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md), we are continuing to cull BinaryFormatter functionality from our libraries and to wean developers off of the type.

In .NET 7, we will default the `SYSLIB0011` obsoletion code to be _an error_ rather than a warning across all C# and VB project types. This affects the following APIs:

* `System.Exception.SerializeObjectState` event
* `System.Runtime.Serialization.Formatter.Deserialize` method
* `System.Runtime.Serialization.Formatter.Serialize` method
* `System.Runtime.Serialization.IFormatter.Deserialize` method
* `System.Runtime.Serialization.IFormatter.Serialize` method
* `System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize` method
* `System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Serialize` method

### Am I affected?

Your project will be affected if it meets _all_ of the following criteria:

* It is C# or VB and targets net7.0; _and_
* It directly references one of the APIs listed above; _and_
* It is not already suppressing the `SYSLIB0011` warning code.

Your project will not be affected if it contains only indirect references to the APIs above. For example, if your application consumes SomeDependency.dll, and if that binary references the above-listed APIs, you will not observe any compile-time errors. The compile-time errors will only be raised when compiling code which _directly_ references these APIs.

### What action should I take?

__The best course of action is to [begin migration away from BinaryFormatter](https://aka.ms/binaryformatter) due to its security and reliability flaws.__ BinaryFormatter is slated to be removed from .NET in a future release. The .NET libraries team has already taken a stance that recent types (like `System.Half` and `System.DateOnly`) will not be compatible with BinaryFormatter, and that trend will continue.

If you absolutely must continue to use BinaryFormatter, the error can be suppressed using one of the below mechanisms.

> **Warning:** The suppressions below must be used only as a last resort. The recommended course of action is to migrate away from BinaryFormatter.

#### Suppressing the error at the call site

If you need to call one of the obsolete APIs, you can put suppress the error in your source file directly at the call site. CS and VB examples are provided below.

```cs
// C# example
Stream inputStream = GetInputStream();
BinaryFormatter bf = new BinaryFormatter();
#pragma warning disable SYSLIB0011 // Allow call to dangerous Deserialize method
object deserializedObj = bf.Deserialize(inputStream);
#pragma warning restore SYSLIB0011 // Reenable the error
```

```vb
' VB example
Dim inputStream As Stream = GetInputStream()
Dim bf As New BinaryFormatter()
#Disable Warning SYSLIB0011 ' Allow call to dangerous Deserialize method
Dim deserializedObj As Object = bf.Deserialize(inputStream)
#Enable Warning SYSLIB0011 ' Reenable the error
```

#### Disabling the error project-wide

If you need to suppress the error project-wide, you can modify your .csproj or .vbproj file to convert the error back to a warning. This will cause compilation to match the behavior present in the .NET 5 and .NET 6 SDKs.

> **Warning:** Setting this element may change host behavior. Keep reading for more information.

```xml
<!--
  Merge this with the PropertyGroup element at the top of
  your .csproj or .vbproj file.

  *** WARNING ***
  This enables dangerous code paths in the application.
-->
<PropertyGroup>
    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
</PropertyGroup>
```

If your project compiles with "warnings as errors" enabled, compilation will still fail. (This matches the behavior that shipped in the .NET 5 and .NET 6 SDKs.) If this is the case, you'll still need to suppress the `SYSLIB0011` code in source or in your project file's `<NoWarn>` element. See [the .NET 5 breaking change notice](https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/binaryformatter-serialization-obsolete) for more information.

### The _\<EnableUnsafeBinaryFormatterSerialization\>_ project file element

The `<EnableUnsafeBinaryFormatterSerialization>` project file switch [was introduced in .NET 5](https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/binaryformatter-serialization-obsolete). With .NET 7, the behavior of this switch has changed to control _both_ compilation _and_ host runtime behavior.

The meaning of this switch differs based on project type, as shown below.

#### For library / shared component projects

> For the purposes of this section, "library" basically refers to anything that doesn't contain an app entry point or can't influence host startup config.

* If `<EnableUnsafeBinaryFormatterSerialization>` is `true`:
  * The above-listed APIs are obsolete as warning. Compilation will succeed unless you have "warnings as errors" enabled for your application or you have suppressed the `SYSLIB0011` warning code.
* If `false` or not set:
  * The above-listed APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed.

Notably, depending on host policy, calls into BinaryFormatter might still fail at runtime. For example, ASP.NET 5+ processes by default fail calls into BinaryFormatter at runtime. This behavior is controlled by the app host. Libraries cannot toggle this behavior.

#### For Blazor / MAUI apps

The Blazor and MAUI runtimes forbid calls to BinaryFormatter. Regardless of any value you set for `<EnableUnsafeBinaryFormatterSerialization>`, the calls will fail at runtime. Do not call these APIs from Blazor / MAUI applications.

#### For ASP.NET apps

* If `<EnableUnsafeBinaryFormatterSerialization>` is `true`:
  * The above-listed APIs are obsolete as warning. Compilation will succeed unless you have "warnings as errors" enabled for your application or you have suppressed the `SYSLIB0011` warning code; _and_
  * The runtime will allow calls to BinaryFormatter, regardless of whether the call orginates from your code or from a dependency that you consume.
* If `false` or not set:
  * The above-listed APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed; _and_
  * The runtime will forbid calls to BinaryFormatter, regardless of whether the call originates from your code or from a dependency that you consume.

#### For console apps, WinForms / WPF apps, and all other app types

* If `<EnableUnsafeBinaryFormatterSerialization>` is `true`:
  * The above-listed APIs are obsolete as warning. Compilation will succeed unless you have "warnings as errors" enabled for your application or you have suppressed the `SYSLIB0011` warning code; _and_
  * The runtime will allow calls to BinaryFormatter, regardless of whether the call orginates from your code or from a dependency that you consume.
* If set to `false`:
  * The above-listed APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed; _and_
  * The runtime will forbid calls to BinaryFormatter, regardless of whether the call originates from your code or from a dependency that you consume.
* If not set:
  * The above-listed APIs are obsolete as error, and calls from your code to those APIs will fail at compile time unless the error is suppressed; _and_
  * The runtime will allow calls to BinaryFormatter, regardless of whether the call orginates from your code or from a dependency that you consume.

> Future versions of .NET may further restrict the default app host behavior with regard to BinaryFormatter. For example, a future .NET may forbid _all_ calls to BinaryFormatter by default for all project types - even if those calls originate in a dependency rather than directly within your application code. Any such changes will be communicated in future breaking change notices.
